### PR TITLE
fix: :bug: remove index button for testing sentry

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -46,14 +46,6 @@ const Index: React.FC = () => {
                   </Text>
                 </Group>
               </Card>
-              <button
-                type="button"
-                onClick={() => {
-                  throw new Error("Sentry Frontend Error");
-                }}
-              >
-                Throw error
-              </button>
             </Col>
           </Grid>
         </Paper>


### PR DESCRIPTION
index page had a useless button which was once meant for testing sentry's catching
